### PR TITLE
Add QUIT to the list of commands acceptable for PUBSUB channels

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -122,3 +122,11 @@ class TestClient(AsyncTestCase):
         client.close()
         with self.assertRaises(IOError):
             client._stream.read_bytes(1024, lambda x: x)
+
+    def test_pubsub_disconnect(self):
+        client = Client(io_loop=self.io_loop)
+        client.connect()
+        client.subscribe("foo", lambda: None)
+        client.close()
+        with self.assertRaises(IOError):
+            client._stream.read_bytes(1024, lambda x: x)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -60,6 +60,7 @@ class TestClient(AsyncTestCase):
         self.assertTrue(result is not None, 'result is %s' % result)
         self.assertEqual(time_string, result)
 
+    @gen.engine
     def test_sub_command(self):
         client = Client(io_loop=self.io_loop)
         result = {"message_count": 0}

--- a/toredis/client.py
+++ b/toredis/client.py
@@ -90,7 +90,7 @@ class Client(RedisCommandsMixin):
         cmd = args[0]
 
         if (self._sub_callback is not None and
-            cmd not in ('PSUBSCRIBE', 'SUBSCRIBE', 'PUNSUBSCRIBE', 'UNSUBSCRIBE')):
+            cmd not in ('PSUBSCRIBE', 'SUBSCRIBE', 'PUNSUBSCRIBE', 'UNSUBSCRIBE', 'QUIT')):
             raise ValueError('Cannot run normal command over PUBSUB connection')
 
         # Send command


### PR DESCRIPTION
I have a long-running Tornado server where I'd like to have a number of relatively short-lived Redis PUBSUB connections (one per HTTP client connection). To avoid this set of Redis connections growing indefinitely, I want to close them once the HTTP client disconnects. However, Toredis currently asserts that QUIT cannot (as a normal command) be run on PUBSUB connections.

This change adds QUIT to the whitelist of commands for PUBSUB connections. I've added a unit test for the behaviour (which fails as expected without the change to the whitelist), and it appears to work as desired in my application. I can't see anything in the Redis documentation that says QUIT can't be used on PUBSUB channels; however, if I'm missing some subtlety let me know and I'll investigate further.