### PR TITLE
Wait until the stream is connected before reading

### DIFF
--- a/toredis/client.py
+++ b/toredis/client.py
@@ -182,8 +182,13 @@ class Client(RedisCommandsMixin):
         self._reset()
 
         self._stream = IOStream(sock, io_loop=self._io_loop)
-        self._stream.connect(addr, callback=callback)
-        self._stream.read_until_close(self._on_close, self._on_read)
+
+        def _stream_connect_callback():
+            callback()
+
+            self._stream.read_until_close(self._on_close, self._on_read)
+
+        self._stream.connect(addr, callback=_stream_connect_callback)
 
     # Event handlers
     def _on_read(self, data):


### PR DESCRIPTION
Calling `read_until_close` immediately after `connect` may cause an error because the stream might not be connected yet. Calling `read_until_close` in the stream's connect callback can avoid the error.