### PR TITLE
Check to ensure pipeline arguments are not empty before sending.

### DIFF
--- a/toredis/client.py
+++ b/toredis/client.py
@@ -108,6 +108,11 @@ class Client(RedisCommandsMixin):
             :param callback:
                 Callback
         """
+        if not args_pipeline:
+            # Exit immediately if there's no pipeline commands
+            # Otherwise registering callback white sending empty message
+            #   will cause callback mismatch going forward
+            return
 
         if self._sub_callback is not None:
             raise ValueError('Cannot run pipeline over PUBSUB connection')


### PR DESCRIPTION
Added empty check to `Client.send_messages` to avoid registering callbacks without sending valid redis commands with pipeline.